### PR TITLE
no default type for params defined by schema

### DIFF
--- a/lib/Dancer/Plugin/Swagger.pm
+++ b/lib/Dancer/Plugin/Swagger.pm
@@ -216,12 +216,16 @@ register swagger_path => sub {
                 $value->{name} = $k;
                 $k = $value;
             }
+            if (!exists($k->{schema}) && !exists($k->{type})) {
+                # set a default type iff it's missing and this doesn't reference a schema
+                $k->{type} = 'string';
+            }
             push @p, $k;
         }
         $p = \@p;
 
         # set defaults
-        $p = [ map { +{ in => 'query', type => 'string', %$_ } } @$p ];
+        $p = [ map { +{ in => 'query', %$_ } } @$p ];
         
         $arg->{parameters} = $p;
     }


### PR DESCRIPTION
Found an issue where defining a param via a schema blew up because the plugin was setting a default type of 'string'.

I believe this fixes it. 